### PR TITLE
Add Android.mk to support compiling on Android-x86

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,13 @@
+#
+# Copyright (C) 2018 The Android-x86 Open Source Project
+#
+# Licensed under the GNU General Public License Version 2 or later.
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.gnu.org/licenses/gpl.html
+#
+
+LOCAL_PATH := $(my-dir)
+LOCAL_MODULE := $(notdir $(LOCAL_PATH))
+EXTRA_KERNEL_MODULE_PATH_$(LOCAL_MODULE) := $(LOCAL_PATH)


### PR DESCRIPTION
If anyone want to compile on Android-x86 they just need to clone it on /external/kernel-drivers and then it will compile.