### PR TITLE
FIX: 8821CE causes random freezes on HP Pavilion 14-ce0019nf

### DIFF
--- a/pci.c
+++ b/pci.c
@@ -1690,7 +1690,7 @@ static int disable_pci_caps(const struct dmi_system_id *dmi)
 }
 
 static const struct dmi_system_id rtw88_pci_quirks[] = {
-	{
+        {
 		.callback = disable_pci_caps,
 		.ident = "Protempo Ltd L116HTN6SPW",
 		.matches = {
@@ -1698,8 +1698,17 @@ static const struct dmi_system_id rtw88_pci_quirks[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "L116HTN6SPW"),
 		},
 		.driver_data = (void *)BIT(QUIRK_DIS_PCI_CAP_ASPM),
+	},	
+	{
+		.callback = disable_pci_caps,
+		.ident = "HP HP Pavilion Laptop 14-ce0xxx",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "HP"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "HP Pavilion Laptop 14-ce0xxx"),
+		},
+		.driver_data = (void *)BIT(QUIRK_DIS_PCI_CAP_ASPM),
 	},
-	{}
+        {}
 };
 
 int rtw_pci_probe(struct pci_dev *pdev,


### PR DESCRIPTION
I witnessed freezes caused by the 8821ce module on my HP Pavilion 14-ce0019nf.
A similar issue was fixed by commit 01274e92 so I added a new quirk to disable the ASPM capability when running on a HP 14-ce0xxx laptop, as Ping-Ke Shih did in the commit I mentioned.

Tested on my own computer, seems to work perfectly since.