### PR TITLE
Add support for Realtek 8821CE RFE Type 6

### DIFF
--- a/rtw8821c.c
+++ b/rtw8821c.c
@@ -1514,6 +1514,7 @@ static const struct rtw_rfe_def rtw8821c_rfe_defs[] = {
 	[0] = RTW_DEF_RFE(8821c, 0, 0),
 	[2] = RTW_DEF_RFE_EXT(8821c, 0, 0, 2),
 	[4] = RTW_DEF_RFE_EXT(8821c, 0, 0, 2),
+	[6] = RTW_DEF_RFE(8821c, 0, 0),
 };
 
 static struct rtw_hw_reg rtw8821c_dig[] = {


### PR DESCRIPTION
- RTL8821CE 802.11ac PCIe [10ec:c821] tells "rfe 6 isn't supported" in kernel log;
- As seen here: https://www.spinics.net/lists/linux-wireless/msg217116.html

some [more info](https://github.com/masterzorag/rtw88/commit/7941e613c2df50d578b1bb77ca93ef45db93cdcb#commitcomment-62733211)