### PR TITLE
Fix DKMS make clean code 

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,7 @@
 PACKAGE_NAME="rtlwifi-new"
 PACKAGE_VERSION=0.6
 MAKE="make -C $kernel_source_dir M=$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION/build"
-CLEAN="make -C $kernel_source_dir clean"
+CLEAN="make clean"
 BUILT_MODULE_NAME[0]="rtw_pci"
 BUILT_MODULE_NAME[1]="rtw_8723de"
 BUILT_MODULE_NAME[2]="rtw_8723d"


### PR DESCRIPTION
This code fixed the issue that the DKMS make clean delete some header files from the kernel and break all other DKMS package as reported in https://github.com/lwfinger/rtw88/issues/126. It built successfully without the problems, but I haven't done any function testing.