### PR TITLE
Fix strlen buffer overflow in alt_rtl8821ce

### DIFF
--- a/alt_rtl8821ce/include/hal_data.h
+++ b/alt_rtl8821ce/include/hal_data.h
@@ -342,7 +342,12 @@ struct txpwr_lmt_ent {
 		[MAX_TX_COUNT];
 #endif
 
+
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
+	char regd_name[];
+	#else
 	char regd_name[0];
+	#endif
 };
 #endif /* CONFIG_TXPWR_LIMIT */
 

--- a/alt_rtl8821ce/include/rtw_rf.h
+++ b/alt_rtl8821ce/include/rtw_rf.h
@@ -264,7 +264,11 @@ struct regd_exc_ent {
 	_list list;
 	char country[2];
 	u8 domain;
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
+	char regd_name[];
+	#else
 	char regd_name[0];
+	#endif
 };
 
 void dump_regd_exc_list(void *sel, struct rf_ctl_t *rfctl);


### PR DESCRIPTION
Since Kernel version 6.5, the driver was no longer loading. In the kernel logs:

```
detected buffer overflow in __fortify_strlen
------------[ cut here ]------------
kernel BUG at lib/string_helpers.c:1031!
<...>
<TASK>
? die+0x36/0x90
? do_trap+0xda/0x100
? fortify_panic+0x13/0x20
? do_error_trap+0x6a/0x90
? fortify_panic+0x13/0x20
? exc_invalid_op+0x50/0x70
? fortify_panic+0x13/0x20
? asm_exc_invalid_op+0x1a/0x20
? fortify_panic+0x13/0x20
rtw_txpwr_lmt_add_with_nlen+0xb0/0x420 [8821ce]
rtw_txpwr_lmt_add+0x50/0x70 [8821ce]
phy_set_tx_power_limit_ex+0x2d7/0x3f0 [8821ce]
odm_config_bb_txpwr_lmt_8821c_ex+0x2c/0x40 [8821ce]
odm_read_and_config_mp_8821c_txpwr_lmt+0x66/0xa0 [8821ce]
odm_config_rf_with_header_file+0xe3/0x140 [8821ce]
phy_load_tx_power_limit+0xd3/0x620 [8821ce]
? PHY_TxPowerByRateConfiguration+0x2d2/0x2f0 [8821ce]
phy_load_tx_power_ext_info+0x6e/0x70 [8821ce]
rtw_hal_dm_init+0x43/0x60 [8821ce]
rtw_init_drv_sw+0x36b/0x3b0 [8821ce]
rtw_pci_primary_adapter_init+0x12a/0x210 [8821ce]
rtw_drv_init+0x890/0xa10 [8821ce]
local_pci_probe+0x42/0xa0
pci_device_probe+0xc7/0x240
really_probe+0x19b/0x3e0
? __pfx___driver_attach+0x10/0x10
__driver_probe_device+0x78/0x160
driver_probe_device+0x1f/0x90
__driver_attach+0xd2/0x1c0
bus_for_each_dev+0x85/0xd0
bus_add_driver+0x116/0x220
driver_register+0x59/0x100
? __pfx_rtw_drv_entry+0x10/0x10 [8821ce]
rtw_drv_entry+0x5e/0xff0 [8821ce]
? __pfx_rtw_drv_entry+0x10/0x10 [8821ce]
do_one_initcall+0x5a/0x320
do_init_module+0x60/0x240
__do_sys_init_module+0x17f/0x1b0
? __seccomp_filter+0x32c/0x4f0
do_syscall_64+0x5d/0x90
? exc_page_fault+0x7f/0x180
entry_SYSCALL_64_after_hwframe+0x6e/0xd8
RIP: 0033:0x7f328d7359ae
```

This PR is a port of the [fix](https://github.com/tomaspinho/rtl8821ce/pull/334) from tomaspinho's repository. I tried it and it works normally.