### PR TITLE
Makefile: Fix depmod arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ ifeq ($(COMPRESS_ZSTD), y)
 	@zstd -f -q --rm $(MODDESTDIR)/*.ko
 endif
 
-	depmod -a $(KVER)
+	depmod $(DEPMOD_ARGS) -a $(KVER)
 
 	@echo "Install rtw88 SUCCESS"
 


### PR DESCRIPTION
Commit d831da23cd363ff970bf50f86bee623970ad9cba removed the DEPMOD_ARGS variable from depmod command. This commit adds it back so it can work properly when INSTALL_MOD_PATH is provided.

We use this driver in the NVIDIA's custom kernel from EVE-OS (https://github.com/lf-edge/eve / https://github.com/lf-edge/eve-kernel/blob/eve-kernel-arm64-v5.10.104-nvidia/Dockerfile.gcc#L145) and the current rtw88's master branch is breaking our build.... 

@lwfinger, once this PR is merged, could you please create a tag so we can point to a known working version in our Dockerfile? I thank you in advance...