### PR TITLE
 add options for setting KSRC and KVER via environmental variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/sh
-KVER  ?= $(shell uname -r)
-KSRC := /lib/modules/$(KVER)/build
+KVER ?= $(if $(KERNELRELEASE),$(KERNELRELEASE),$(shell uname -r))
+KSRC ?= $(if $(KERNEL_SRC),$(KERNEL_SRC),/lib/modules/$(KVER)/build)
 FIRMWAREDIR := /lib/firmware/
 PWD := $(shell pwd)
 CLR_MODULE_FILES := *.mod.c *.mod *.o .*.cmd *.ko *~ .tmp_versions* modules.order Module.symvers


### PR DESCRIPTION
Just as is done in your Makefile of the rtl8188eu driver. Give option to set KVER and KSRC via the environmental variables KERNELRELEASE and KERNEL_SRC or revert to default. 