### PR TITLE
rtw88: Remove duplicated code

### DIFF
--- a/mac.c
+++ b/mac.c
@@ -955,18 +955,6 @@ static int __rtw_download_firmware_legacy(struct rtw_dev *rtwdev,
 		rtw_write8(rtwdev, REG_MCUFW_CTRL, 0x00);
 	}
 
-	/* reset firmware if still present */
-	if (rtwdev->chip->id == RTW_CHIP_TYPE_8703B &&
-	    rtw_read8_mask(rtwdev, REG_MCUFW_CTRL, BIT_RAM_DL_SEL)) {
-		rtw_write8(rtwdev, REG_MCUFW_CTRL, 0x00);
-	}
-
-	/* reset firmware if still present */
-	if (rtwdev->chip->id == RTW_CHIP_TYPE_8703B &&
-	    rtw_read8_mask(rtwdev, REG_MCUFW_CTRL, BIT_RAM_DL_SEL)) {
-		rtw_write8(rtwdev, REG_MCUFW_CTRL, 0x00);
-	}
-
 	en_download_firmware_legacy(rtwdev, true);
 	ret = download_firmware_legacy(rtwdev, fw->firmware->data, fw->firmware->size);
 	en_download_firmware_legacy(rtwdev, false);

--- a/usb.c
+++ b/usb.c
@@ -93,11 +93,6 @@ static u32 rtw_usb_read(struct rtw_dev *rtwdev, u32 addr, u16 len)
 	    rtwdev->chip->id == RTW_CHIP_TYPE_8821C)
 		rtw_usb_reg_sec(rtwdev, addr, data);
 
-	if (rtwdev->chip->id == RTW_CHIP_TYPE_8822C ||
-	    rtwdev->chip->id == RTW_CHIP_TYPE_8822B ||
-	    rtwdev->chip->id == RTW_CHIP_TYPE_8821C)
-		rtw_usb_reg_sec(rtwdev, addr, data);
-
 	return le32_to_cpu(*data);
 }
 


### PR DESCRIPTION
Remove some code blocks that was added by mistake, likely during a merge conflict handling. Also remove some dead code.