### PR TITLE
wifi: rtw88: handle PCI_IRQ_INTX changes

### DIFF
--- a/pci.c
+++ b/pci.c
@@ -1613,7 +1613,11 @@ static struct rtw_hci_ops rtw_pci_ops = {
 
 static int rtw_pci_request_irq(struct rtw_dev *rtwdev, struct pci_dev *pdev)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0))
+	unsigned int flags = PCI_IRQ_INTX;
+#else
 	unsigned int flags = PCI_IRQ_LEGACY;
+#endif
 	int ret;
 
 	if (!rtw_disable_msi)


### PR DESCRIPTION
PCI_IRQ_LEGACY is deprecated/replaced by PCI_IRQ_INTX since [0] and removed in [1] so add handling for Linux 6.10.y else compile fails.

[0] https://patchwork.kernel.org/project/linux-pci/patch/20230802094036.1052472-2-dlemoal@kernel.org/
[1] https://patchwork.kernel.org/project/linux-usb/cover/20240325070944.3600338-1-dlemoal@kernel.org/