### PR TITLE
Update for compilation in kernel v6.11

### DIFF
--- a/mac80211.c
+++ b/mac80211.c
@@ -64,7 +64,11 @@ static int rtw_ops_start(struct ieee80211_hw *hw)
 	return ret;
 }
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0))
 static void rtw_ops_stop(struct ieee80211_hw *hw)
+#else
+static void rtw_ops_stop(struct ieee80211_hw *hw, bool suspend)
+#endif
 {
 	struct rtw_dev *rtwdev = hw->priv;
 


### PR DESCRIPTION
Kernel v6.11 introduces a new `suspend` parameter for the `stop` function pointer in `struct ieee80211_ops` of mac80211.  This change adds this parameter to the local `rtw_ops_stop` function to allow for successful compilation.