### PR TITLE
Support old C99 Kernel Compile

### DIFF
--- a/rtw8723x.c
+++ b/rtw8723x.c
@@ -99,6 +99,7 @@ static void __rtw8723x_debug_txpwr_limit(struct rtw_dev *rtwdev,
 					 struct rtw_txpwr_idx *table,
 					 int tx_path_count)
 {
+	int i;
 	if (!rtw_dbg_is_enabled(rtwdev, RTW_DBG_EFUSE))
 		return;
 
@@ -107,7 +108,7 @@ static void __rtw8723x_debug_txpwr_limit(struct rtw_dev *rtwdev,
 	/* CCK base */
 	rtw_dbg(rtwdev, RTW_DBG_EFUSE, "CCK base\n");
 	rtw_dbg(rtwdev, RTW_DBG_EFUSE, "RF    G0  G1  G2  G3  G4  G5\n");
-	for (int i = 0; i < tx_path_count; i++)
+	for (i = 0; i < tx_path_count; i++)
 		rtw_dbg(rtwdev, RTW_DBG_EFUSE,
 			"[%c]: %3u %3u %3u %3u %3u %3u\n",
 			'A' + i,
@@ -120,7 +121,7 @@ static void __rtw8723x_debug_txpwr_limit(struct rtw_dev *rtwdev,
 	/* CCK diff */
 	rtw_dbg(rtwdev, RTW_DBG_EFUSE, "CCK diff\n");
 	rtw_dbg(rtwdev, RTW_DBG_EFUSE, "RF   1S 2S 3S 4S\n");
-	for (int i = 0; i < tx_path_count; i++)
+	for (i = 0; i < tx_path_count; i++)
 		rtw_dbg(rtwdev, RTW_DBG_EFUSE,
 			"[%c]: %2d %2d %2d %2d\n",
 			'A' + i, 0 /* no diff for 1S */,
@@ -130,7 +131,7 @@ static void __rtw8723x_debug_txpwr_limit(struct rtw_dev *rtwdev,
 	/* BW40-1S base */
 	rtw_dbg(rtwdev, RTW_DBG_EFUSE, "BW40-1S base\n");
 	rtw_dbg(rtwdev, RTW_DBG_EFUSE, "RF    G0  G1  G2  G3  G4\n");
-	for (int i = 0; i < tx_path_count; i++)
+	for (i = 0; i < tx_path_count; i++)
 		rtw_dbg(rtwdev, RTW_DBG_EFUSE,
 			"[%c]: %3u %3u %3u %3u %3u\n",
 			'A' + i,
@@ -142,7 +143,7 @@ static void __rtw8723x_debug_txpwr_limit(struct rtw_dev *rtwdev,
 	/* OFDM diff */
 	rtw_dbg(rtwdev, RTW_DBG_EFUSE, "OFDM diff\n");
 	rtw_dbg(rtwdev, RTW_DBG_EFUSE, "RF   1S 2S 3S 4S\n");
-	for (int i = 0; i < tx_path_count; i++)
+	for (i = 0; i < tx_path_count; i++)
 		rtw_dbg(rtwdev, RTW_DBG_EFUSE,
 			"[%c]: %2d %2d %2d %2d\n",
 			'A' + i,
@@ -153,7 +154,7 @@ static void __rtw8723x_debug_txpwr_limit(struct rtw_dev *rtwdev,
 	/* BW20 diff */
 	rtw_dbg(rtwdev, RTW_DBG_EFUSE, "BW20 diff\n");
 	rtw_dbg(rtwdev, RTW_DBG_EFUSE, "RF   1S 2S 3S 4S\n");
-	for (int i = 0; i < tx_path_count; i++)
+	for (i = 0; i < tx_path_count; i++)
 		rtw_dbg(rtwdev, RTW_DBG_EFUSE,
 			"[%c]: %2d %2d %2d %2d\n",
 			'A' + i,
@@ -164,7 +165,7 @@ static void __rtw8723x_debug_txpwr_limit(struct rtw_dev *rtwdev,
 	/* BW40 diff */
 	rtw_dbg(rtwdev, RTW_DBG_EFUSE, "BW40 diff\n");
 	rtw_dbg(rtwdev, RTW_DBG_EFUSE, "RF   1S 2S 3S 4S\n");
-	for (int i = 0; i < tx_path_count; i++)
+	for (i = 0; i < tx_path_count; i++)
 		rtw_dbg(rtwdev, RTW_DBG_EFUSE,
 			"[%c]: %2d %2d %2d %2d\n",
 			'A' + i, 0 /* no diff for 1S */,

--- a/rtw8723x.h
+++ b/rtw8723x.h
@@ -511,7 +511,8 @@ rtw8723x_iqk_restore_lte_path_gnt(struct rtw_dev *rtwdev,
 /* set all ADDA registers to the given value */
 static inline void rtw8723x_iqk_path_adda_on(struct rtw_dev *rtwdev, u32 value)
 {
-	for (int i = 0; i < RTW8723X_IQK_ADDA_REG_NUM; i++)
+	int i;
+	for (i = 0; i < RTW8723X_IQK_ADDA_REG_NUM; i++)
 		rtw_write32(rtwdev, rtw8723x_common.iqk_adda_regs[i], value);
 }
 


### PR DESCRIPTION
The old C syntax does not allow loop initialization variable type
for(int i=0 ....
into
int i;
for (i=0