### PR TITLE
Makefile: update secure boot CN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ clean:
 
 sign:
 ifeq ($(NO_SKIP_SIGN), y)
-	@openssl req -new -x509 -newkey rsa:2048 -keyout MOK.priv -outform DER -out MOK.der -nodes -days 36500 -subj "/CN=Custom MOK/"
+	@openssl req -new -x509 -newkey rsa:2048 -keyout MOK.priv -outform DER -out MOK.der -nodes -days 36500 -subj "/CN=rtw88 driver key/"
 	@mokutil --import MOK.der
 else
 	echo "Skipping key creation"


### PR DESCRIPTION
The secure boot CN is updated to be less ambiguous.


After uninstalling the driver, I wanted to clean up my secure boot enrolled keys. The Makefile generates a key is named `Custom MOK` the naming was vague and I had to do a bit more investigation to figure which key to delete.

This PR renames the key CN to make life a bit easier for others who uninstall the driver.