### PR TITLE
Add support for TP-LINK Archer T2UB Nano

### DIFF
--- a/rtw8821cu.c
+++ b/rtw8821cu.c
@@ -37,6 +37,8 @@ static const struct usb_device_id rtw_8821cu_id_table[] = {
 	  .driver_info = (kernel_ulong_t)&(rtw8821c_hw_spec) }, /* Edimax */
 	{ USB_DEVICE_AND_INTERFACE_INFO(0x7392, 0xd811, 0xff, 0xff, 0xff),
 	  .driver_info = (kernel_ulong_t)&(rtw8821c_hw_spec) }, /* Edimax */
+	{ USB_DEVICE_AND_INTERFACE_INFO(0x2357, 0x013c, 0xff, 0xff, 0xff),
+	  .driver_info = (kernel_ulong_t)&(rtw8821c_hw_spec) }, /* TP-LINK Archer T2UB Nano */
 	{},
 };
 MODULE_DEVICE_TABLE(usb, rtw_8821cu_id_table);


### PR DESCRIPTION
This USB ID (2357:013c) is found at:
https://wikidevi.wi-cat.ru/TP-LINK_Archer_T2UB_Nano

Link to the driver for Windows:
https://www.tp-link.com/en/support/download/archer-t2ub-nano/

