### PR TITLE
rtw88: don't ask for TX report for management frames for 8723cs

### DIFF
--- a/sdio.c
+++ b/sdio.c
@@ -1201,11 +1201,14 @@ static void rtw_sdio_indicate_tx_status(struct rtw_dev *rtwdev,
 	struct rtw_sdio_tx_data *tx_data = rtw_sdio_get_tx_data(skb);
 	struct ieee80211_tx_info *info = IEEE80211_SKB_CB(skb);
 	struct ieee80211_hw *hw = rtwdev->hw;
+	struct ieee80211_hdr *hdr;
 
 	skb_pull(skb, rtwdev->chip->tx_pkt_desc_sz);
+	hdr = (struct ieee80211_hdr *)skb->data;
 
 	/* enqueue to wait for tx report */
-	if (info->flags & IEEE80211_TX_CTL_REQ_TX_STATUS) {
+	if ((info->flags & IEEE80211_TX_CTL_REQ_TX_STATUS) &&
+	    !(rtwdev->chip->id == RTW_CHIP_TYPE_8703B && ieee80211_is_mgmt(hdr->frame_control))) {
 		rtw_tx_report_enqueue(rtwdev, skb, tx_data->sn);
 		return;
 	}


### PR DESCRIPTION
RTL8723CS doesn't provide TX reports for frames sent through the management queue. RTL8814AU has similar behavior.

This is not a big problem in station mode. It just results in "failed to get tx report from firmware" when connecting to a network but the connection works. But in AP mode clients can't connect at all.

One way to fix it is to ignore IEEE80211_TX_CTL_REQ_TX_STATUS when transmitting management frames for the this particular chip type.

The change based on fix for RTL8814AU - e15c59e8fd83 ("wifi: rtw88: 8814au: Don't ask for TX report for management frames").


Link: https://github.com/lwfinger/rtw88/commit/e15c59e8fd8361258747a898d7b2f86344bb33fb