### PR TITLE
dkms: remove deprecated CLEAN feature

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,6 @@
 PACKAGE_NAME="rtw88"
 PACKAGE_VERSION="0.6"
 MAKE="KVER=${kernelver} 'make' all"
-CLEAN="KVER=${kernelver} 'make' clean"
 AUTOINSTALL=yes
 
 BUILT_MODULE_NAMES=(


### PR DESCRIPTION
It's safe to just drop this option.

Fixes #367