### PR TITLE
Sync with wireless-next

### DIFF
--- a/coex.c
+++ b/coex.c
@@ -485,6 +485,13 @@ static void rtw_coex_monitor_bt_ctr(struct rtw_dev *rtwdev)
 		"[BTCoex], Hi-Pri Rx/Tx: %d/%d, Lo-Pri Rx/Tx: %d/%d\n",
 		coex_stat->hi_pri_rx, coex_stat->hi_pri_tx,
 		coex_stat->lo_pri_rx, coex_stat->lo_pri_tx);
+
+	if (coex_stat->wl_under_lps || coex_stat->wl_under_ips ||
+	    (coex_stat->hi_pri_rx > 60000 && coex_stat->hi_pri_tx == 60000 &&
+	     coex_stat->lo_pri_rx > 60000 && coex_stat->lo_pri_tx == 60000))
+		coex_stat->bt_ctr_ok = false;
+	else
+		coex_stat->bt_ctr_ok = true;
 }
 
 static void rtw_coex_monitor_bt_enable(struct rtw_dev *rtwdev)
@@ -1959,13 +1966,17 @@ static void rtw_coex_action_bt_hid(struct rtw_dev *rtwdev)
 	struct rtw_coex *coex = &rtwdev->coex;
 	struct rtw_coex_stat *coex_stat = &coex->stat;
 	struct rtw_efuse *efuse = &rtwdev->efuse;
+	bool is_bt_ctr_hi = false, is_toggle_table = false;
 	u8 table_case, tdma_case;
 	u32 slot_type = 0;
-	bool bt_multi_link_remain = false, is_toggle_table = false;
 
 	rtw_dbg(rtwdev, RTW_DBG_COEX, "[BTCoex], %s()\n", __func__);
 	rtw_coex_set_ant_path(rtwdev, false, COEX_SET_ANT_2G);
 	rtw_coex_set_rf_para(rtwdev, chip->wl_rf_para_rx[0]);
+
+	if (coex_stat->bt_ctr_ok &&
+	    coex_stat->lo_pri_rx + coex_stat->lo_pri_tx > 360)
+		is_bt_ctr_hi = true;
 
 	if (efuse->share_ant) {
 		/* Shared-Ant */
@@ -1980,28 +1991,31 @@ static void rtw_coex_action_bt_hid(struct rtw_dev *rtwdev)
 			}
 		} else {
 			/* Legacy HID  */
-			if (coex_stat->bt_profile_num == 1 &&
-			    (coex_stat->bt_multi_link ||
-			    (coex_stat->lo_pri_rx +
-			     coex_stat->lo_pri_tx > 360) ||
-			     coex_stat->bt_slave ||
-			     bt_multi_link_remain)) {
-				slot_type = TDMA_4SLOT;
-				table_case = 12;
-				tdma_case = 20;
-			} else if (coex_stat->bt_a2dp_active) {
+			if (coex_stat->bt_a2dp_active) {
 				table_case = 9;
 				tdma_case = 18;
+			} else if (coex_stat->bt_profile_num == 1 &&
+				   (coex_stat->bt_multi_link &&
+				    (is_bt_ctr_hi || coex_stat->bt_slave ||
+				     coex_stat->bt_multi_link_remain))) {
+				if (coex_stat->wl_gl_busy &&
+				    (coex_stat->wl_rx_rate <= 3 ||
+				     coex_stat->wl_rts_rx_rate <= 3))
+					table_case = 13;
+				else
+					table_case = 12;
+
+				tdma_case = 26;
 			} else if (coex_stat->bt_418_hid_exist &&
 				   coex_stat->wl_gl_busy) {
 				is_toggle_table = true;
 				slot_type = TDMA_4SLOT;
-				table_case = 9;
-				tdma_case = 24;
+				table_case = 32;
+				tdma_case = 27;
 			} else if (coex_stat->bt_ble_hid_exist &&
 				   coex_stat->wl_gl_busy) {
-				table_case = 32;
-				tdma_case = 9;
+				table_case = 36;
+				tdma_case = 0;
 			} else {
 				table_case = 9;
 				tdma_case = 9;

--- a/fw.c
+++ b/fw.c
@@ -1363,7 +1363,7 @@ static struct rtw_rsvd_page *rtw_alloc_rsvd_page(struct rtw_dev *rtwdev,
 	struct rtw_rsvd_page *rsvd_pkt = NULL;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
-	rsvd_pkt = kzalloc_obj(*rsvd_pkt, GFP_KERNEL);
+	rsvd_pkt = kzalloc_obj(*rsvd_pkt);
 #else
 	rsvd_pkt = kzalloc(sizeof(*rsvd_pkt), GFP_KERNEL);
 #endif

--- a/fw.c
+++ b/fw.c
@@ -1362,7 +1362,11 @@ static struct rtw_rsvd_page *rtw_alloc_rsvd_page(struct rtw_dev *rtwdev,
 {
 	struct rtw_rsvd_page *rsvd_pkt = NULL;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	rsvd_pkt = kzalloc_obj(*rsvd_pkt, GFP_KERNEL);
+#else
 	rsvd_pkt = kzalloc(sizeof(*rsvd_pkt), GFP_KERNEL);
+#endif
 
 	if (!rsvd_pkt)
 		return NULL;

--- a/main.c
+++ b/main.c
@@ -1912,6 +1912,7 @@ static void rtw_load_firmware_cb(const struct firmware *firmware, void *context)
 {
 	struct rtw_fw_state *fw = context;
 	struct rtw_dev *rtwdev = fw->rtwdev;
+	struct wiphy *wiphy = rtwdev->hw->wiphy;
 
 	if (!firmware || !firmware->data) {
 		rtw_err(rtwdev, "failed to request firmware\n");
@@ -1926,6 +1927,11 @@ static void rtw_load_firmware_cb(const struct firmware *firmware, void *context)
 	rtw_info(rtwdev, "%sFirmware version %u.%u.%u, H2C version %u\n",
 		 fw->type == RTW_WOWLAN_FW ? "WOW " : "",
 		 fw->version, fw->sub_version, fw->sub_index, fw->h2c_version);
+
+	if (fw->type == RTW_NORMAL_FW)
+		snprintf(wiphy->fw_version, sizeof(wiphy->fw_version),
+			 "%u.%u.%u",
+			 fw->version, fw->sub_version, fw->sub_index);
 }
 
 static int rtw_load_firmware(struct rtw_dev *rtwdev, enum rtw_fw_type type)

--- a/main.h
+++ b/main.h
@@ -1631,6 +1631,7 @@ struct rtw_coex_stat {
 	bool bt_game_hid_exist;
 	bool bt_hid_handle_cnt;
 	bool bt_mailbox_reply;
+	bool bt_ctr_ok;
 
 	bool wl_under_lps;
 	bool wl_under_ips;

--- a/main.h
+++ b/main.h
@@ -580,6 +580,11 @@ enum rtw_wow_flags {
 	RTW_WOW_FLAG_MAX,
 };
 
+enum rtw_quirk_dis_caps {
+	QUIRK_DIS_CAP_PCI_ASPM,
+	QUIRK_DIS_CAP_LPS_DEEP,
+};
+
 /* the power index is represented by differences, which cck-1s & ht40-1s are
  * the base values, so for 1s's differences, there are only ht20 & ofdm
  */

--- a/pci.c
+++ b/pci.c
@@ -1873,7 +1873,8 @@ int rtw_pci_probe(struct pci_dev *pdev,
 	}
 
 	/* Disable PCIe ASPM L1 while doing NAPI poll for 8821CE */
-	if (rtwdev->chip->id == RTW_CHIP_TYPE_8821C && bridge->vendor == PCI_VENDOR_ID_INTEL)
+	if (rtwdev->chip->id == RTW_CHIP_TYPE_8821C &&
+	    bridge && bridge->vendor == PCI_VENDOR_ID_INTEL)
 		rtwpci->rx_no_aspm = true;
 
 	rtw_pci_phy_cfg(rtwdev);

--- a/pci.c
+++ b/pci.c
@@ -2,6 +2,7 @@
 /* Copyright(c) 2018-2019  Realtek Corporation
  */
 
+#include <linux/dmi.h>
 #include <linux/module.h>
 #include <linux/pci.h>
 #include "main.h"
@@ -1779,6 +1780,34 @@ const struct pci_error_handlers rtw_pci_err_handler = {
 };
 EXPORT_SYMBOL(rtw_pci_err_handler);
 
+static int rtw_pci_disable_caps(const struct dmi_system_id *dmi)
+{
+	uintptr_t dis_caps = (uintptr_t)dmi->driver_data;
+
+	if (dis_caps & BIT(QUIRK_DIS_CAP_PCI_ASPM))
+		rtw_pci_disable_aspm = true;
+
+	if (dis_caps & BIT(QUIRK_DIS_CAP_LPS_DEEP))
+		rtw_disable_lps_deep_mode = true;
+
+	return 1;
+}
+
+static const struct dmi_system_id rtw_pci_quirks[] = {
+	{
+		.callback = rtw_pci_disable_caps,
+		.ident = "HP Notebook - P3S95EA#ACB",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "HP"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "HP Notebook"),
+			DMI_MATCH(DMI_PRODUCT_SKU, "P3S95EA#ACB"),
+		},
+		.driver_data = (void *)(BIT(QUIRK_DIS_CAP_PCI_ASPM) |
+					BIT(QUIRK_DIS_CAP_LPS_DEEP)),
+	},
+	{}
+};
+
 int rtw_pci_probe(struct pci_dev *pdev,
 		  const struct pci_device_id *id)
 {
@@ -1808,6 +1837,8 @@ int rtw_pci_probe(struct pci_dev *pdev,
 	atomic_set(&rtwpci->link_usage, 1);
 
 	rtwpci->gen = pci_info->pci_gen;
+
+	dmi_check_system(rtw_pci_quirks);
 
 	ret = rtw_core_init(rtwdev);
 	if (ret)

--- a/rtw8703b.c
+++ b/rtw8703b.c
@@ -1809,6 +1809,11 @@ static const struct coex_table_para table_sant_8703b[] = {
 	{0x66556aaa, 0x6a5a6aaa}, /* case-30 */
 	{0xffffffff, 0x5aaa5aaa},
 	{0x56555555, 0x5a5a5aaa},
+	{0xdaffdaff, 0xdaffdaff},
+	{0xddffddff, 0xddffddff},
+	{0xe5555555, 0xe5555555}, /* case-35 */
+	{0xea5a5a5a, 0xea5a5a5a},
+	{0xea6a6a6a, 0xea6a6a6a},
 };
 
 /* Shared-Antenna TDMA */

--- a/rtw8723d.c
+++ b/rtw8723d.c
@@ -1459,6 +1459,11 @@ static const struct coex_table_para table_sant_8723d[] = {
 	{0x66556aaa, 0x6a5a6aaa}, /* case-30 */
 	{0xffffffff, 0x5aaa5aaa},
 	{0x56555555, 0x5a5a5aaa},
+	{0xdaffdaff, 0xdaffdaff},
+	{0xddffddff, 0xddffddff},
+	{0xe5555555, 0xe5555555}, /* case-35 */
+	{0xea5a5a5a, 0xea5a5a5a},
+	{0xea6a6a6a, 0xea6a6a6a},
 };
 
 /* Non-Shared-Antenna Coex Table */

--- a/rtw8821a.c
+++ b/rtw8821a.c
@@ -1000,7 +1000,12 @@ static const struct coex_table_para table_sant_8821a[] = {
 	{0x66556655, 0x66556655},
 	{0x66556aaa, 0x6a5a6aaa}, /* case-30 */
 	{0xffffffff, 0x5aaa5aaa},
-	{0x56555555, 0x5a5a5aaa}
+	{0x56555555, 0x5a5a5aaa},
+	{0xdaffdaff, 0xdaffdaff},
+	{0xddffddff, 0xddffddff},
+	{0xe5555555, 0xe5555555}, /* case-35 */
+	{0xea5a5a5a, 0xea5a5a5a},
+	{0xea6a6a6a, 0xea6a6a6a},
 };
 
 /* Non-Shared-Antenna Coex Table */

--- a/rtw8821c.c
+++ b/rtw8821c.c
@@ -1728,7 +1728,12 @@ static const struct coex_table_para table_sant_8821c[] = {
 	{0x66556655, 0x66556655},
 	{0x66556aaa, 0x6a5a6aaa}, /* case-30 */
 	{0xffffffff, 0x5aaa5aaa},
-	{0x56555555, 0x5a5a5aaa}
+	{0x56555555, 0x5a5a5aaa},
+	{0xdaffdaff, 0xdaffdaff},
+	{0xddffddff, 0xddffddff},
+	{0xe5555555, 0xe5555555}, /* case-35 */
+	{0xea5a5a5a, 0xea5a5a5a},
+	{0xea6a6a6a, 0xea6a6a6a},
 };
 
 /* Non-Shared-Antenna Coex Table */

--- a/rtw8822b.c
+++ b/rtw8822b.c
@@ -2219,6 +2219,11 @@ static const struct coex_table_para table_sant_8822b[] = {
 	{0x66556aaa, 0x6a5a6aaa}, /* case-30 */
 	{0xffffffff, 0x5aaa5aaa},
 	{0x56555555, 0x5a5a5aaa},
+	{0xdaffdaff, 0xdaffdaff},
+	{0xddffddff, 0xddffddff},
+	{0xe5555555, 0xe5555555}, /* case-35 */
+	{0xea5a5a5a, 0xea5a5a5a},
+	{0xea6a6a6a, 0xea6a6a6a},
 };
 
 /* Non-Shared-Antenna Coex Table */

--- a/rtw8822c.c
+++ b/rtw8822c.c
@@ -5037,6 +5037,9 @@ static const struct coex_table_para table_sant_8822c[] = {
 	{0x56555555, 0x5a5a5aaa},
 	{0xdaffdaff, 0xdaffdaff},
 	{0xddffddff, 0xddffddff},
+	{0xe5555555, 0xe5555555}, /* case-35 */
+	{0xea5a5a5a, 0xea5a5a5a},
+	{0xea6a6a6a, 0xea6a6a6a},
 };
 
 /* Non-Shared-Antenna Coex Table */
@@ -5403,7 +5406,7 @@ const struct rtw_chip_info rtw8822c_hw_spec = {
 	.max_sched_scan_ssids = 4,
 #endif
 	.max_scan_ie_len = (RTW_PROBE_PG_CNT - 1) * TX_PAGE_SIZE,
-	.coex_para_ver = 0x22020720,
+	.coex_para_ver = 0x26020420,
 	.bt_desired_ver = 0x20,
 	.scbd_support = true,
 	.new_scbd10_def = true,

--- a/rx.c
+++ b/rx.c
@@ -322,6 +322,14 @@ void rtw_rx_query_rx_desc(struct rtw_dev *rtwdev, void *rx_desc8,
 
 	pkt_stat->tsf_low = le32_get_bits(rx_desc->w5, RTW_RX_DESC_W5_TSFL);
 
+	if (unlikely(pkt_stat->rate >= DESC_RATE_MAX)) {
+		rtw_dbg(rtwdev, RTW_DBG_UNEXP,
+			"unexpected RX rate=0x%x\n", pkt_stat->rate);
+
+		pkt_stat->rate = DESC_RATE1M;
+		pkt_stat->bw = RTW_CHANNEL_WIDTH_20;
+	}
+
 	/* drv_info_sz is in unit of 8-bytes */
 	pkt_stat->drv_info_sz *= 8;
 

--- a/sdio.c
+++ b/sdio.c
@@ -1293,8 +1293,13 @@ static int rtw_sdio_init_tx(struct rtw_dev *rtwdev)
 
 	for (i = 0; i < RTK_MAX_TX_QUEUE_NUM; i++)
 		skb_queue_head_init(&rtwsdio->tx_queue[i]);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	rtwsdio->tx_handler_data = kmalloc_obj(*rtwsdio->tx_handler_data,
+					       GFP_KERNEL);
+#else
 	rtwsdio->tx_handler_data = kmalloc(sizeof(*rtwsdio->tx_handler_data),
 					   GFP_KERNEL);
+#endif
 	if (!rtwsdio->tx_handler_data)
 		goto err_destroy_wq;
 

--- a/sdio.c
+++ b/sdio.c
@@ -1294,8 +1294,7 @@ static int rtw_sdio_init_tx(struct rtw_dev *rtwdev)
 	for (i = 0; i < RTK_MAX_TX_QUEUE_NUM; i++)
 		skb_queue_head_init(&rtwsdio->tx_queue[i]);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
-	rtwsdio->tx_handler_data = kmalloc_obj(*rtwsdio->tx_handler_data,
-					       GFP_KERNEL);
+	rtwsdio->tx_handler_data = kmalloc_obj(*rtwsdio->tx_handler_data);
 #else
 	rtwsdio->tx_handler_data = kmalloc(sizeof(*rtwsdio->tx_handler_data),
 					   GFP_KERNEL);

--- a/usb.c
+++ b/usb.c
@@ -995,7 +995,10 @@ static int rtw_usb_init_rx(struct rtw_dev *rtwdev)
 	struct sk_buff *rx_skb;
 	int i;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0)
+	rtwusb->rxwq = alloc_workqueue("rtw88_usb: rx wq", WQ_BH | WQ_PERCPU,
+				       0);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0)
 	rtwusb->rxwq = alloc_workqueue("rtw88_usb: rx wq", WQ_BH, 0);
 #else
 	tasklet_init(&rtwusb->rx_tasklet, rtw_usb_rx_handler,

--- a/usb.c
+++ b/usb.c
@@ -403,7 +403,11 @@ static bool rtw_usb_tx_agg_skb(struct rtw_usb *rtwusb, struct sk_buff_head *list
 	if (skb_queue_empty(list))
 		return false;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	txcb = kmalloc_obj(*txcb, GFP_ATOMIC);
+#else
 	txcb = kmalloc(sizeof(*txcb), GFP_ATOMIC);
+#endif
 	if (!txcb)
 		return false;
 

--- a/usb.c
+++ b/usb.c
@@ -1087,7 +1087,7 @@ static int rtw_usb_intf_init(struct rtw_dev *rtwdev,
 			     struct usb_interface *intf)
 {
 	struct rtw_usb *rtwusb = rtw_get_usb_priv(rtwdev);
-	struct usb_device *udev = usb_get_dev(interface_to_usbdev(intf));
+	struct usb_device *udev = interface_to_usbdev(intf);
 	int ret;
 
 	rtwusb->udev = udev;
@@ -1113,7 +1113,6 @@ static void rtw_usb_intf_deinit(struct rtw_dev *rtwdev,
 {
 	struct rtw_usb *rtwusb = rtw_get_usb_priv(rtwdev);
 
-	usb_put_dev(rtwusb->udev);
 	kfree(rtwusb->usb_data);
 	usb_set_intfdata(intf, NULL);
 }

--- a/util.c
+++ b/util.c
@@ -122,7 +122,11 @@ static void rtw_collect_sta_iter(void *data, struct ieee80211_sta *sta)
 	struct rtw_iter_stas_data *iter_stas = data;
 	struct rtw_stas_entry *stas_entry;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	stas_entry = kmalloc_obj(*stas_entry, GFP_ATOMIC);
+#else
 	stas_entry = kmalloc(sizeof(*stas_entry), GFP_ATOMIC);
+#endif
 	if (!stas_entry)
 		return;
 
@@ -172,7 +176,11 @@ static void rtw_collect_vif_iter(void *data, u8 *mac, struct ieee80211_vif *vif)
 	struct rtw_iter_vifs_data *iter_stas = data;
 	struct rtw_vifs_entry *vifs_entry;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	vifs_entry = kmalloc_obj(*vifs_entry, GFP_ATOMIC);
+#else
 	vifs_entry = kmalloc(sizeof(*vifs_entry), GFP_ATOMIC);
+#endif
 	if (!vifs_entry)
 		return;
 


### PR DESCRIPTION
Tested with 8822BU on
Arch Linux (kernel version: 7.0.0-1-mainline, 6.6.127-1-lts66, 5.15.201-1-lts515)
Linux Mint 20.3 (kernel version: 5.4.0-91-generic)

https://github.com/torvalds/linux/commit/bad909507a4b55818612b24733279c473b3f1663 is not included. I think we can merge it when it is necessary for our driver here.