### PR TITLE
wifi: rtw88: Add debugfs knob to force the monitor channel

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -97,6 +97,7 @@ struct rtw_debugfs {
 	struct rtw_debugfs_priv fw_crash;
 	struct rtw_debugfs_priv force_lowest_basic_rate;
 	struct rtw_debugfs_priv dm_cap;
+	struct rtw_debugfs_priv monitor_channel;
 };
 
 static const char * const rtw_dm_cap_strs[] = {
@@ -1185,6 +1186,62 @@ static int rtw_debugfs_get_dm_cap(struct seq_file *m, void *v)
 	.cb_read = rtw_debugfs_get_ ##name,			\
 }
 
+static ssize_t rtw_debugfs_set_monitor_channel(struct file *filp,
+					       const char __user *buffer,
+					       size_t count, loff_t *loff)
+{
+	struct seq_file *seqpriv = (struct seq_file *)filp->private_data;
+	struct rtw_debugfs_priv *debugfs_priv = seqpriv->private;
+	struct rtw_dev *rtwdev = debugfs_priv->rtwdev;
+	u8 channel;
+	int ret;
+
+	ret = kstrtou8_from_user(buffer, count, 0, &channel);
+	if (ret)
+		return ret;
+
+	if (channel) {
+		enum nl80211_band band = channel <= 14 ?
+			NL80211_BAND_2GHZ : NL80211_BAND_5GHZ;
+		int freq = ieee80211_channel_to_frequency(channel, band);
+		struct ieee80211_channel *chan =
+			ieee80211_get_channel(rtwdev->hw->wiphy, freq);
+
+		if (!chan || chan->flags & IEEE80211_CHAN_DISABLED) {
+			rtw_warn(rtwdev, "monitor_channel: channel %u not available\n",
+				 channel);
+			return -EINVAL;
+		}
+	}
+
+	mutex_lock(&rtwdev->mutex);
+	rtwdev->mon_chan = channel;
+	rtw_leave_lps_deep(rtwdev);
+	rtw_set_channel(rtwdev);
+	mutex_unlock(&rtwdev->mutex);
+
+	rtw_dbg(rtwdev, RTW_DBG_DEBUGFS,
+		"forced monitor channel set to %u (0 = mac80211 controlled)\n",
+		channel);
+
+	return count;
+}
+
+static int rtw_debugfs_get_monitor_channel(struct seq_file *m, void *v)
+{
+	struct rtw_debugfs_priv *debugfs_priv = m->private;
+	struct rtw_dev *rtwdev = debugfs_priv->rtwdev;
+
+	if (rtwdev->mon_chan)
+		seq_printf(m, "forced channel %u (20 MHz); hw channel %u\n",
+			   rtwdev->mon_chan, rtwdev->hal.current_channel);
+	else
+		seq_printf(m, "off (mac80211 controlled); hw channel %u\n",
+			   rtwdev->hal.current_channel);
+
+	return 0;
+}
+
 static const struct rtw_debugfs rtw_debugfs_templ = {
 	.mac_0 = rtw_debug_priv_mac(0x0000),
 	.mac_1 = rtw_debug_priv_mac(0x0100),
@@ -1239,6 +1296,7 @@ static const struct rtw_debugfs rtw_debugfs_templ = {
 	.fw_crash = rtw_debug_priv_set_and_get(fw_crash),
 	.force_lowest_basic_rate = rtw_debug_priv_set_and_get(force_lowest_basic_rate),
 	.dm_cap = rtw_debug_priv_set_and_get(dm_cap),
+	.monitor_channel = rtw_debug_priv_set_and_get(monitor_channel),
 };
 
 #define rtw_debugfs_add_core(name, mode, fopname, parent)		\
@@ -1279,6 +1337,7 @@ void rtw_debugfs_add_basic(struct rtw_dev *rtwdev, struct dentry *debugfs_topdir
 	rtw_debugfs_add_rw(fw_crash);
 	rtw_debugfs_add_rw(force_lowest_basic_rate);
 	rtw_debugfs_add_rw(dm_cap);
+	rtw_debugfs_add_rw(monitor_channel);
 }
 
 static

--- a/main.c
+++ b/main.c
@@ -884,10 +884,32 @@ void rtw_set_channel(struct rtw_dev *rtwdev)
 	const struct rtw_chip_info *chip = rtwdev->chip;
 	struct ieee80211_hw *hw = rtwdev->hw;
 	struct rtw_hal *hal = &rtwdev->hal;
+	struct cfg80211_chan_def *chandef = &hw->conf.chandef;
+	struct cfg80211_chan_def mon_chandef = {};
 	struct rtw_channel_params ch_param;
 	u8 center_chan, primary_chan, bandwidth, band;
 
-	rtw_get_channel_params(&hw->conf.chandef, &ch_param);
+	/* When a monitor channel is forced via debugfs, ignore whatever
+	 * channel mac80211 asks for (e.g. the channel 1 it programs when an
+	 * unassociated station vif is brought up on kernels >= 6.9) and pin
+	 * the RF to the requested 20 MHz channel instead.
+	 */
+	if (rtwdev->mon_chan) {
+		enum nl80211_band nl_band = rtwdev->mon_chan <= 14 ?
+			NL80211_BAND_2GHZ : NL80211_BAND_5GHZ;
+		int freq = ieee80211_channel_to_frequency(rtwdev->mon_chan,
+							  nl_band);
+		struct ieee80211_channel *chan =
+			ieee80211_get_channel(hw->wiphy, freq);
+
+		if (chan && !(chan->flags & IEEE80211_CHAN_DISABLED)) {
+			cfg80211_chandef_create(&mon_chandef, chan,
+						NL80211_CHAN_NO_HT);
+			chandef = &mon_chandef;
+		}
+	}
+
+	rtw_get_channel_params(chandef, &ch_param);
 	if (WARN(ch_param.center_chan == 0, "Invalid channel\n"))
 		return;
 

--- a/main.h
+++ b/main.h
@@ -2289,6 +2289,14 @@ struct rtw_dev {
 	char led_name[32];
 	struct led_classdev led_cdev;
 
+	/* Force the RF to a fixed channel for monitor-mode frame injection,
+	 * bypassing mac80211's channel arbitration. On kernels >= 6.9 an up
+	 * non-monitor vif otherwise pins the hardware to channel 1 and blocks
+	 * monitor channel changes. 0 = mac80211 controlled, always 20 MHz.
+	 * Controlled via the "monitor_channel" debugfs file.
+	 */
+	u8 mon_chan;
+
 	/* hci related data, must be last */
 	u8 priv[] __aligned(sizeof(void *));
 };


### PR DESCRIPTION
On kernels >= 6.9, mac80211's channel-context emulation re-pins the radio to channel 1 whenever an unassociated station vif is brought up, and rejects "iw dev <mon> set channel" on a monitor interface with -EBUSY. This breaks monitor-mode frame injection setups that keep a station interface up (e.g. for hardware auto-ACK) next to a monitor interface: the RF ends up stuck on channel 1 regardless of the channel requested on the monitor.

Add an opt-in "monitor_channel" debugfs file. Writing a channel number stores it in rtwdev->mon_chan and makes rtw_set_channel() build a forced 20 MHz chandef for that channel instead of using hw->conf.chandef, so the RF is pinned to the requested channel and survives mac80211 reprogramming it. Writing 0 restores normal mac80211 control. The default is 0 (disabled), so behaviour is unchanged unless the knob is used.

Tested on RTL8814AU (USB) against a real AP on channel 6: without the knob the radio pins to channel 1 and probe/auth/assoc/EAPOL injection fails; with the knob the radio stays on channel 6 with the station vif up (so hardware auto-ACK keeps working) and injection succeeds.